### PR TITLE
Fix: Use run.sh wrapper to locate python3 on macOS

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -64,7 +64,7 @@
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
-				<string>ConnectionSearcher.py</string>
+				<string>run.sh</string>
 				<key>subtext</key>
 				<string>Find and open saved connection in JumpDesktop</string>
 				<key>title</key>

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Try to find python3
+if command -v python3 >/dev/null 2>&1; then
+    python3 ConnectionSearcher.py "$@"
+    exit $?
+fi
+
+# Common paths for python3
+PATHS=(
+    "/usr/local/bin/python3"
+    "/opt/homebrew/bin/python3"
+    "/usr/bin/python3"
+    "${HOME}/.pyenv/shims/python3"
+    "${HOME}/anaconda3/bin/python3"
+    "${HOME}/miniconda3/bin/python3"
+)
+
+for py in "${PATHS[@]}"; do
+    if [ -x "$py" ]; then
+        "$py" ConnectionSearcher.py "$@"
+        exit $?
+    fi
+done
+
+# Fallback
+if command -v python >/dev/null 2>&1; then
+    # Check if it looks like python 3
+    VER=$(python --version 2>&1)
+    if [[ "$VER" == *"Python 3"* ]]; then
+        python ConnectionSearcher.py "$@"
+        exit $?
+    fi
+fi
+
+echo "Python 3 not found. Please install Python 3." >&2
+exit 1


### PR DESCRIPTION
Introduces run.sh to dynamically locate Python 3 interpreter in common locations (PATH, Homebrew, etc.) and updates info.plist to use this wrapper. This solves execution issues on macOS environments where default python path is not standard.

---
*PR created automatically by Jules for task [16930142667579862623](https://jules.google.com/task/16930142667579862623) started by @yaoxinghuo*